### PR TITLE
doc clarify full path needed for configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ These are the following commands available from the `kelp` binary:
 
 The `trade` command has three parameters which are:
 
-- **botConf**: _.cfg_ file with the account details, [sample file here](examples/configs/trader/sample_trader.cfg).
+- **botConf**: full path to the _.cfg_ file with the account details, [sample file here](examples/configs/trader/sample_trader.cfg).
 - **strategy**: the strategy you want to run (_sell_, _buysell_, _balanced_, _mirror_, _delete_).
-- **stratConf**: _.cfg_ file specific to your chosen strategy, [sample files here](examples/configs/trader/).
+- **stratConf**: full path to the _.cfg_ file specific to your chosen strategy, [sample files here](examples/configs/trader/).
 
 Here's an example of how to start the trading bot with the _buysell_ strategy:
 
-`kelp trade --botConf trader.cfg --strategy buysell --stratConf buysell.cfg`
+`kelp trade --botConf ./path/trader.cfg --strategy buysell --stratConf ./path/buysell.cfg`
 
 If you are ever stuck, just invoke the `kelp` binary directly or type `kelp help [command]` for help with a specific command.
 

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stellar/go/support/config"
 )
 
-const tradeExamples = `  kelp trade --botConf trader.cfg --strategy buysell --stratConf buysell.cfg
-  kelp trade --botConf trader.cfg --strategy buysell --stratConf buysell.cfg --sim`
+const tradeExamples = `  kelp trade --botConf .path/trader.cfg --strategy buysell --stratConf .path/buysell.cfg
+  kelp trade --botConf .path/trader.cfg --strategy buysell --stratConf .path/buysell.cfg --sim`
 
 var tradeCmd = &cobra.Command{
 	Use:     "trade",

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stellar/go/support/config"
 )
 
-const tradeExamples = `  kelp trade --botConf .path/trader.cfg --strategy buysell --stratConf .path/buysell.cfg
-  kelp trade --botConf .path/trader.cfg --strategy buysell --stratConf .path/buysell.cfg --sim`
+const tradeExamples = `  kelp trade --botConf ./path/trader.cfg --strategy buysell --stratConf ./path/buysell.cfg
+  kelp trade --botConf ./path/trader.cfg --strategy buysell --stratConf ./path/buysell.cfg --sim`
 
 var tradeCmd = &cobra.Command{
 	Use:     "trade",

--- a/examples/walkthroughs/trader/balanced.md
+++ b/examples/walkthroughs/trader/balanced.md
@@ -64,7 +64,7 @@ The virtual balance combined with the actual balance the bot has in its account 
 Assuming your botConfig is called `trader.cfg` and your strategy config is called `balanced.cfg`, you can run `kelp` with the following command:
 
 ```
-kelp trade --botConf trader.cfg --strategy balanced --stratConf balanced.cfg
+kelp trade --botConf .path/trader.cfg --strategy balanced --stratConf .path/balanced.cfg
 ```
 
 # Above and Beyond

--- a/examples/walkthroughs/trader/balanced.md
+++ b/examples/walkthroughs/trader/balanced.md
@@ -64,7 +64,7 @@ The virtual balance combined with the actual balance the bot has in its account 
 Assuming your botConfig is called `trader.cfg` and your strategy config is called `balanced.cfg`, you can run `kelp` with the following command:
 
 ```
-kelp trade --botConf .path/trader.cfg --strategy balanced --stratConf .path/balanced.cfg
+kelp trade --botConf ./path/trader.cfg --strategy balanced --stratConf ./path/balanced.cfg
 ```
 
 # Above and Beyond

--- a/examples/walkthroughs/trader/buysell.md
+++ b/examples/walkthroughs/trader/buysell.md
@@ -41,9 +41,9 @@ A level defines a [layer](https://en.wikipedia.org/wiki/Layering_(finance)) that
 
 ## Run Kelp
 
-Assuming your botConfig is called `trader.cfg` and your strategy config is called `buysell.cfg`:
+Assuming your botConfig is called `trader.cfg` and your strategy config is called `buysell.cfg`, you can run `kelp` with the following command:
 ```
-kelp trade --botConf .path/trader.cfg --strategy buysell --stratConf .path/buysell.cfg
+kelp trade --botConf ./path/trader.cfg --strategy buysell --stratConf ./path/buysell.cfg
 ```
 
 # Above and Beyond

--- a/examples/walkthroughs/trader/buysell.md
+++ b/examples/walkthroughs/trader/buysell.md
@@ -41,9 +41,9 @@ A level defines a [layer](https://en.wikipedia.org/wiki/Layering_(finance)) that
 
 ## Run Kelp
 
-Assuming your botConfig is called `trader.cfg` and your strategy config is called `buysell.cfg`, and they are in the directory `$GOPATH/configs` you can run `kelp` with the following command:
+Assuming your botConfig is called `trader.cfg` and your strategy config is called `buysell.cfg`:
 ```
-kelp trade --botConf $GOPATH/configs/trader.cfg --strategy buysell --stratConf $GOPATH/configs/buysell.cfg
+kelp trade --botConf .path/trader.cfg --strategy buysell --stratConf .path/buysell.cfg
 ```
 
 # Above and Beyond

--- a/examples/walkthroughs/trader/buysell.md
+++ b/examples/walkthroughs/trader/buysell.md
@@ -41,9 +41,9 @@ A level defines a [layer](https://en.wikipedia.org/wiki/Layering_(finance)) that
 
 ## Run Kelp
 
-Assuming your botConfig is called `trader.cfg` and your strategy config is called `buysell.cfg`, you can run `kelp` with the following command:
+Assuming your botConfig is called `trader.cfg` and your strategy config is called `buysell.cfg`, and they are in the directory `$GOPATH/configs` you can run `kelp` with the following command:
 ```
-kelp trade --botConf trader.cfg --strategy buysell --stratConf buysell.cfg
+kelp trade --botConf $GOPATH/configs/trader.cfg --strategy buysell --stratConf $GOPATH/configs/buysell.cfg
 ```
 
 # Above and Beyond

--- a/examples/walkthroughs/trader/sell.md
+++ b/examples/walkthroughs/trader/sell.md
@@ -48,7 +48,7 @@ A level defines a [layer](https://en.wikipedia.org/wiki/Layering_(finance)) that
 Assuming your botConfig is called `trader.cfg` and your strategy config is called `sell.cfg`, you can run `kelp`  with the following command:
 
 ```
-kelp trade --botConf .path/trader.cfg --strategy sell --stratConf .path/sell.cfg
+kelp trade --botConf ./path/trader.cfg --strategy sell --stratConf ./path/sell.cfg
 ```
 
 # Above and Beyond

--- a/examples/walkthroughs/trader/sell.md
+++ b/examples/walkthroughs/trader/sell.md
@@ -48,7 +48,7 @@ A level defines a [layer](https://en.wikipedia.org/wiki/Layering_(finance)) that
 Assuming your botConfig is called `trader.cfg` and your strategy config is called `sell.cfg`, you can run `kelp`  with the following command:
 
 ```
-kelp trade --botConf trader.cfg --strategy sell --stratConf sell.cfg
+kelp trade --botConf .path/trader.cfg --strategy sell --stratConf .path/sell.cfg
 ```
 
 # Above and Beyond


### PR DESCRIPTION
Edit trade examples to clarify that the full path to the file is required.

The examples at present don't make it clear that the path to the _.cfg_ file is required for the config flags. This made it difficult for me as a new user to get started.