### PR TITLE
Ccxt integration to support priceFeeds and orderbooks from multiple exchanges

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ To compile Kelp from source:
     * `./scripts/build.sh`
 6. Confirm one new binary file:
     * `./bin/kelp`
+7. Set up CCXT to use an expanded set of priceFeeds or orderbooks (see the [Using CCXT](#using-ccxt) section for details)
 
 ## Running Kelp
 
@@ -124,9 +125,9 @@ If you are ever stuck, just invoke the `kelp` binary directly or type `kelp help
 
 ## Using CCXT
 
-You can use the [CCXT][ccxt] library via the [CCXT REST API Wrapper][ccxt-rest] to fetch prices from a larger number of exchanges.
+You can use the [CCXT][ccxt] library via the [CCXT REST API Wrapper][ccxt-rest] to fetch prices and orderbooks from a larger number of exchanges.
 
-You will need to run the CCXT REST server on `localhost:3000` so Kelp can connect to it. In order to run CCXT you should install [docker][docker] (`sudo apt install -y docker.io`) and run the CCXT-REST docker image configured to port `3000` (`sudo docker run -p 3000:3000 -d franzsee/ccxt-rest`). You can find more details on the [CCXT_REST github page][ccxt-rest]. The CCXT-REST server **must** be running before you start up the Kelp bot.
+You will need to run the CCXT REST server on `localhost:3000` so Kelp can connect to it. In order to run CCXT you should install [docker][docker] (linux: `sudo apt install -y docker.io`) and run the CCXT-REST docker image configured to port `3000` (linux: `sudo docker run -p 3000:3000 -d franzsee/ccxt-rest`). You can find more details on the [CCXT_REST github page][ccxt-rest]. The CCXT-REST server **must** be running on port `3000` before you start up the Kelp bot.
 
 You can list the exchanges (`./kelp exchanges`) to get the full list of supported exchanges via CCXT.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ To learn more about the Stellar protocol check out [this video created by Lumena
       * [Download Binary](#download-binary)
       * [Compile from Source](#compile-from-source)
       * [Running Kelp](#running-kelp)
+      * [Using CCXT](#using-ccxt)
       * [Be Smart and Go Slow](#be-smart-and-go-slow)
    * [Components](#components)
       * [Strategies](#strategies)
@@ -121,6 +122,16 @@ Here's an example of how to start the trading bot with the _buysell_ strategy:
 
 If you are ever stuck, just invoke the `kelp` binary directly or type `kelp help [command]` for help with a specific command.
 
+## Using CCXT
+
+You can use the [CCXT][ccxt] library via the [CCXT REST API Wrapper][ccxt-rest] to fetch prices from a larger number of exchanges.
+
+You will need to run the CCXT REST server on `localhost:3000` so Kelp can connect to it. In order to run CCXT you should install [docker][docker] (`sudo apt install -y docker.io`) and run the CCXT-REST docker image configured to port `3000` (`sudo docker run -p 3000:3000 -d franzsee/ccxt-rest`). You can find more details on the [CCXT_REST github page][ccxt-rest]. The CCXT-REST server **must** be running before you start up the Kelp bot.
+
+You can list the exchanges (`./kelp exchanges`) to get the full list of supported exchanges via CCXT.
+
+_Note: this integration is still **experimental** and is also **incomplete**. Please use at your own risk._
+
 ## Be Smart and Go Slow
 
 _Whenever you trade on Stellar, you are trading with volatile assets, in volatile markets, and you risk losing money. Use Kelp at your own risk. There is no guarantee you'll make a profit from using our bots or strategies. In fact, if you set bad parameters or market conditions change, Kelp might help you **lose** money very fast. So be smart and go slow._
@@ -175,7 +186,7 @@ Price Feeds fetch the price of an asset from an external source. The following p
 
 - coinmarketcap: fetches the price of tokens from [CoinMarketCap][cmc]
 - fiat: fetches the price of a [fiat][fiat] currency from the [CurrencyLayer API][currencylayer]
-- exchange: fetches the price from an exchange you specify, such as Kraken or Poloniex
+- exchange: fetches the price from an exchange you specify, such as Kraken or Poloniex. You can also use the [CCXT][ccxt] integration to fetch prices from a wider range of exchanges (see the [Using CCXT](#using-ccxt) section for details)
 - fixed: sets the price to a constant
 
 ## Configuration Files
@@ -280,6 +291,9 @@ See the [Changelog](CHANGELOG.md).
 [cmc]: https://coinmarketcap.com/
 [fiat]: https://en.wikipedia.org/wiki/Fiat_money
 [currencylayer]: https://currencylayer.com/
+[ccxt]: https://github.com/ccxt/ccxt
+[ccxt-rest]: https://github.com/franz-see/ccxt-rest
+[docker]: https://www.docker.com/
 [kraken]: https://www.kraken.com/
 [stellar-downloader]: https://github.com/nikhilsaraf/stellar-downloader
 [stackexchange]: https://stellar.stackexchange.com/

--- a/accounting/pnl/pnl.go
+++ b/accounting/pnl/pnl.go
@@ -68,12 +68,20 @@ func getTotalNativeValue(address string, cmcRef string) float64 {
 		} else {
 			cryptoBal = bal
 
-			nativePriceInUSD, e := makeCmcFeed("stellar").GetPrice()
+			pf, e := makeCmcFeed("stellar")
+			if e != nil {
+				log.Fatal(e)
+			}
+			nativePriceInUSD, e := pf.GetPrice()
 			if e != nil {
 				log.Fatal(e)
 			}
 
-			cryptoPriceInUSD, e := makeCmcFeed(cmcRef).GetPrice()
+			pf, e = makeCmcFeed(cmcRef)
+			if e != nil {
+				log.Fatal(e)
+			}
+			cryptoPriceInUSD, e := pf.GetPrice()
 			if e != nil {
 				log.Fatal(e)
 			}
@@ -100,7 +108,7 @@ func loadAccount(client *horizon.Client, address string) horizon.Account {
 	return account
 }
 
-func makeCmcFeed(cmcRef string) api.PriceFeed {
+func makeCmcFeed(cmcRef string) (api.PriceFeed, error) {
 	url := fmt.Sprintf("https://api.coinmarketcap.com/v1/ticker/%s/", cmcRef)
 	return plugins.MakePriceFeed("crypto", url)
 }

--- a/api/exchange.go
+++ b/api/exchange.go
@@ -13,10 +13,8 @@ type Account interface {
 
 // Ticker encapsulates all the data for a given Trading Pair
 type Ticker struct {
-	AskPrice  *model.Number
-	AskVolume *model.Number
-	BidPrice  *model.Number
-	BidVolume *model.Number
+	AskPrice *model.Number
+	BidPrice *model.Number
 }
 
 // TradesResult is the result of a GetTrades call

--- a/api/exchange.go
+++ b/api/exchange.go
@@ -30,13 +30,16 @@ type TradeHistoryResult struct {
 	Trades []model.Trade
 }
 
+// TickerAPI is the interface we use as a generic API for getting ticker data from any crypto exchange
+type TickerAPI interface {
+	GetTickerPrice(pairs []model.TradingPair) (map[model.TradingPair]Ticker, error)
+}
+
 // TradeAPI is the interface we use as a generic API for trading on any crypto exchange
 type TradeAPI interface {
 	GetPrecision() int8
 
 	GetAssetConverter() *model.AssetConverter
-
-	GetTickerPrice(pairs []model.TradingPair) (map[model.TradingPair]Ticker, error)
 
 	GetOrderBook(pair *model.TradingPair, maxCount int32) (*model.OrderBook, error)
 
@@ -145,6 +148,7 @@ func MakeErrWithdrawAmountInvalid(amountToWithdraw *model.Number, fee *model.Num
 // Exchange is the interface we use as a generic API for all crypto exchanges
 type Exchange interface {
 	Account
+	TickerAPI
 	TradeAPI
 	DepositAPI
 	WithdrawAPI

--- a/api/exchange.go
+++ b/api/exchange.go
@@ -35,8 +35,6 @@ type TickerAPI interface {
 
 // TradeAPI is the interface we use as a generic API for trading on any crypto exchange
 type TradeAPI interface {
-	GetPrecision() int8
-
 	GetAssetConverter() *model.AssetConverter
 
 	GetOrderBook(pair *model.TradingPair, maxCount int32) (*model.OrderBook, error)

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -67,10 +67,8 @@ func init() {
 			log.Fatal(e)
 		}
 		log.Printf("Trading %s:%s for %s:%s\n", botConfig.ASSET_CODE_A, botConfig.ISSUER_A, botConfig.ASSET_CODE_B, botConfig.ISSUER_B)
-
-		//Add current strategy to the log
 		log.Printf("Current strategy: %s\n", *strategy)
-		
+
 		client := &horizon.Client{
 			URL:  botConfig.HORIZON_URL,
 			HTTP: http.DefaultClient,
@@ -92,7 +90,11 @@ func init() {
 		assetBase := botConfig.AssetBase()
 		assetQuote := botConfig.AssetQuote()
 		dataKey := model.MakeSortedBotKey(assetBase, assetQuote)
-		strat := plugins.MakeStrategy(sdex, &assetBase, &assetQuote, *strategy, *stratConfigPath)
+		strat, e := plugins.MakeStrategy(sdex, &assetBase, &assetQuote, *strategy, *stratConfigPath)
+		if e != nil {
+			log.Println()
+			log.Fatal(e)
+		}
 		bot := trader.MakeBot(
 			client,
 			botConfig.AssetBase(),
@@ -105,6 +107,7 @@ func init() {
 		)
 		// --- end initialization of objects ---
 
+		log.Println("Starting the trader bot...")
 		for {
 			bot.Start()
 			log.Println("Restarting the trader bot...")

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -68,13 +68,11 @@ func init() {
 			log.Fatal(e)
 		}
 		log.Printf("Trading %s:%s for %s:%s\n", botConfig.ASSET_CODE_A, botConfig.ISSUER_A, botConfig.ASSET_CODE_B, botConfig.ISSUER_B)
-		log.Printf("Current strategy: %s\n", *strategy)
 
 		client := &horizon.Client{
 			URL:  botConfig.HORIZON_URL,
 			HTTP: http.DefaultClient,
 		}
-		validateTrustlines(client, &botConfig)
 
 		// --- start initialization of objects ----
 		sdex := plugins.MakeSDEX(
@@ -109,6 +107,10 @@ func init() {
 			dataKey,
 		)
 		// --- end initialization of objects ---
+
+		log.Printf("validating trustlines...\n")
+		validateTrustlines(client, &botConfig)
+		log.Printf("trustlines valid\n")
 
 		log.Println("Starting the trader bot...")
 		for {

--- a/examples/configs/trader/sample_buysell.cfg
+++ b/examples/configs/trader/sample_buysell.cfg
@@ -11,8 +11,14 @@
 
 DATA_TYPE_A="exchange"
 # the format is <exchange name>/<base-asset-code-defined-by-exchange>/<quote-asset-code-defined-by-exchange>
-# currently we only support the following exchanges: "kraken"
+# currently we only support the following exchanges: "kraken", "ccxt-binance", "ccxt-poloniex", "ccxt-bittrex"
 DATA_FEED_A_URL="kraken/XXLM/ZUSD"
+# uncomment to use binance, poloniex, or bittrex as your price feed. You will need to set up CCXT to use this, see the "Using CCXT" section in the README for details.
+# be careful about using USD vs. USDT since some exchanges support only one, or both, or in some cases neither.
+#DATA_FEED_A_URL="ccxt-binance/XLM/USDT"
+#DATA_FEED_A_URL="ccxt-poloniex/XLM/USDT"
+# bittrex does not have an XLM/USD market so this config lists XLM/BTC instead; you should NOT use this when trying to price an asset based on the XLM/USD price (unless you know what you are doing).
+#DATA_FEED_A_URL="ccxt-bittrex/XLM/BTC"
 
 # sample priceFeed with the "crypto" type
 #DATA_TYPE_A="crypto"

--- a/examples/configs/trader/sample_mirror.cfg
+++ b/examples/configs/trader/sample_mirror.cfg
@@ -1,6 +1,7 @@
 # Sample config file for the "mirror" strategy
 
-# specifies the exchange to use, currently we only support the "kraken" exchange. You can easily add support for your own exchange and set this field once it has been integrated into the bot.
+# specifies the exchange to use, currently we only support the "kraken", "ccxt-binance", "ccxt-poloniex", and "ccxt-bittrex" exchanges. You can easily add support for your own exchange and set this field once it has been integrated into the bot.
+# You will need to set up CCXT to use the CCXT-based exchanges, see the "Using CCXT" section in the README for details.
 EXCHANGE="kraken"
 
 # the base asset as specified by the exchange.
@@ -8,6 +9,22 @@ EXCHANGE_BASE="XXLM"
 
 # the quote asset as specified by the exchange.
 EXCHANGE_QUOTE="ZUSD"
+
+# some alternative setups for ccxt-based exchanges:
+# be careful about using USD vs. USDT since some exchanges support only one, or both, or in some cases neither.
+# binance (these are the only valid values for ORDERBOOK_DEPTH when using binance: 5, 10, 20, 50)
+#EXCHANGE="ccxt-binance"
+#EXCHANGE_BASE="XLM"
+#EXCHANGE_QUOTE="USDT"
+# poloniex
+#EXCHANGE="ccxt-poloniex"
+#EXCHANGE_BASE="XLM"
+#EXCHANGE_QUOTE="USDT"
+# bittrex
+# bittrex does not have an XLM/USD market so this config lists XLM/BTC instead; you should NOT use this when trying to price an asset based on the XLM/USD price (unless you know what you are doing).
+#EXCHANGE="ccxt-bittrex"
+#EXCHANGE_BASE="XLM"
+#EXCHANGE_QUOTE="BTC"
 
 # maximum depth of order levels that we want to create on the orderbook on each side
 ORDERBOOK_DEPTH=40

--- a/examples/configs/trader/sample_sell.cfg
+++ b/examples/configs/trader/sample_sell.cfg
@@ -13,8 +13,14 @@
 
 DATA_TYPE_A="exchange"
 # the format is <exchange name>/<base-asset-code-defined-by-exchange>/<quote-asset-code-defined-by-exchange>
-# currently we only support the following exchanges: "kraken"
+# currently we only support the following exchanges: "kraken", "ccxt-binance", "ccxt-poloniex", "ccxt-bittrex"
 DATA_FEED_A_URL="kraken/XXLM/ZUSD"
+# uncomment to use binance, poloniex, or bittrex as your price feed. You will need to set up CCXT to use this, see the "Using CCXT" section in the README for details.
+# be careful about using USD vs. USDT since some exchanges support only one, or both, or in some cases neither.
+#DATA_FEED_A_URL="ccxt-binance/XLM/USDT"
+#DATA_FEED_A_URL="ccxt-poloniex/XLM/USDT"
+# bittrex does not have an XLM/USD market so this config lists XLM/BTC instead; you should NOT use this when trying to price an asset based on the XLM/USD price (unless you know what you are doing).
+#DATA_FEED_A_URL="ccxt-bittrex/XLM/BTC"
 
 # sample priceFeed with the "crypto" type
 #DATA_TYPE_A="crypto"

--- a/model/assets.go
+++ b/model/assets.go
@@ -122,6 +122,7 @@ var Display = makeAssetConverter(map[Asset]string{
 })
 
 // CcxtAssetConverter is the asset converter for the CCXT exchange interface
+// TODO define a scalable approach to referencing assets using CCXT w.r.t. dev cost
 var CcxtAssetConverter = makeAssetConverter(map[Asset]string{
 	XLM:  string(XLM),
 	BTC:  string(BTC),

--- a/model/assets.go
+++ b/model/assets.go
@@ -121,6 +121,17 @@ var Display = makeAssetConverter(map[Asset]string{
 	KRW:  string(KRW),
 })
 
+// CcxtAssetConverter is the asset converter for the CCXT exchange interface
+var CcxtAssetConverter = makeAssetConverter(map[Asset]string{
+	XLM:  string(XLM),
+	BTC:  string(BTC),
+	USD:  string(USD),
+	ETH:  string(ETH),
+	LTC:  string(LTC),
+	REP:  string(REP),
+	USDT: string(USDT),
+})
+
 // KrakenAssetConverter is the asset converter for the Kraken exchange
 var KrakenAssetConverter = makeAssetConverter(map[Asset]string{
 	XLM:  "XXLM",

--- a/model/assets.go
+++ b/model/assets.go
@@ -125,19 +125,7 @@ var Display = makeAssetConverter(map[Asset]string{
 })
 
 // CcxtAssetConverter is the asset converter for the CCXT exchange interface
-// TODO define a scalable approach to referencing assets using CCXT w.r.t. dev cost
-var CcxtAssetConverter = makeAssetConverter(map[Asset]string{
-	XLM:  string(XLM),
-	BTC:  string(BTC),
-	USD:  string(USD),
-	ETH:  string(ETH),
-	LTC:  string(LTC),
-	REP:  string(REP),
-	BCH:  string(BCH),
-	USDT: string(USDT),
-	ICN:  string(ICN),
-	OMG:  string(OMG),
-})
+var CcxtAssetConverter = Display
 
 // KrakenAssetConverter is the asset converter for the Kraken exchange
 var KrakenAssetConverter = makeAssetConverter(map[Asset]string{

--- a/model/assets.go
+++ b/model/assets.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"errors"
+	"fmt"
 	"log"
 )
 
@@ -83,7 +84,7 @@ func (c AssetConverter) FromString(s string) (Asset, error) {
 func (c AssetConverter) MustFromString(s string) Asset {
 	a, e := c.FromString(s)
 	if e != nil {
-		log.Fatal(e)
+		log.Fatal(fmt.Errorf("exiting on an error-enforced asset conversion: %s", e))
 	}
 	return a
 }

--- a/model/assets.go
+++ b/model/assets.go
@@ -41,6 +41,7 @@ const (
 	GBP  Asset = "GBP"
 	JPY  Asset = "JPY"
 	KRW  Asset = "KRW"
+	OMG  Asset = "OMG"
 )
 
 // AssetConverter converts to and from the asset type, it is specific to an exchange
@@ -120,6 +121,7 @@ var Display = makeAssetConverter(map[Asset]string{
 	GBP:  string(GBP),
 	JPY:  string(JPY),
 	KRW:  string(KRW),
+	OMG:  string(OMG),
 })
 
 // CcxtAssetConverter is the asset converter for the CCXT exchange interface
@@ -131,7 +133,10 @@ var CcxtAssetConverter = makeAssetConverter(map[Asset]string{
 	ETH:  string(ETH),
 	LTC:  string(LTC),
 	REP:  string(REP),
+	BCH:  string(BCH),
 	USDT: string(USDT),
+	ICN:  string(ICN),
+	OMG:  string(OMG),
 })
 
 // KrakenAssetConverter is the asset converter for the Kraken exchange

--- a/model/orderbook.go
+++ b/model/orderbook.go
@@ -111,6 +111,11 @@ type OrderBook struct {
 	bids []Order
 }
 
+// Pair returns trading pair
+func (o OrderBook) Pair() *TradingPair {
+	return o.pair
+}
+
 // Asks returns the asks in an orderbook
 func (o OrderBook) Asks() []Order {
 	return o.asks

--- a/model/tradingPair.go
+++ b/model/tradingPair.go
@@ -42,12 +42,12 @@ func (p TradingPair) ToString(c *AssetConverter, delim string) (string, error) {
 func TradingPairFromString(codeSize int8, c *AssetConverter, p string) (*TradingPair, error) {
 	base, e := c.FromString(p[0:codeSize])
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("base asset could not be converted: %s", e)
 	}
 
 	quote, e := c.FromString(p[codeSize : codeSize*2])
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("quote asset could not be converted: %s", e)
 	}
 
 	return &TradingPair{Base: base, Quote: quote}, nil

--- a/plugins/buysellStrategy.go
+++ b/plugins/buysellStrategy.go
@@ -1,6 +1,8 @@
 package plugins
 
 import (
+	"fmt"
+
 	"github.com/lightyeario/kelp/api"
 	"github.com/lightyeario/kelp/support/utils"
 	"github.com/stellar/go/clients/horizon"
@@ -45,7 +47,7 @@ func makeBuySellStrategy(
 		config.DATA_FEED_B_URL,
 	)
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("cannot make the buysell strategy because we could not make the sell side feed pair: %s", e)
 	}
 	sellSideStrategy := makeSellSideStrategy(
 		sdex,
@@ -75,7 +77,7 @@ func makeBuySellStrategy(
 		config.DATA_FEED_A_URL,
 	)
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("cannot make the buysell strategy because we could not make the buy side feed pair: %s", e)
 	}
 	// switch sides of base/quote here for buy side
 	buySideStrategy := makeSellSideStrategy(

--- a/plugins/ccxtExchange.go
+++ b/plugins/ccxtExchange.go
@@ -50,10 +50,8 @@ func (c ccxtExchange) GetTickerPrice(pairs []model.TradingPair) (map[model.Tradi
 		}
 
 		priceResult[p] = api.Ticker{
-			AskPrice:  model.NumberFromFloat(tickerMap["ask"].(float64), c.precision),
-			AskVolume: model.NumberFromFloat(tickerMap["askVolume"].(float64), c.precision),
-			BidPrice:  model.NumberFromFloat(tickerMap["bid"].(float64), c.precision),
-			BidVolume: model.NumberFromFloat(tickerMap["bidVolume"].(float64), c.precision),
+			AskPrice: model.NumberFromFloat(tickerMap["ask"].(float64), c.precision),
+			BidPrice: model.NumberFromFloat(tickerMap["bid"].(float64), c.precision),
 		}
 	}
 

--- a/plugins/ccxtExchange.go
+++ b/plugins/ccxtExchange.go
@@ -69,12 +69,6 @@ func (c ccxtExchange) GetAccountBalances(assetList []model.Asset) (map[model.Ass
 	return nil, nil
 }
 
-// GetPrecision impl
-func (c ccxtExchange) GetPrecision() int8 {
-	// TODO implement
-	return utils.SdexPrecision
-}
-
 // GetOrderBook impl
 func (c ccxtExchange) GetOrderBook(pair *model.TradingPair, maxCount int32) (*model.OrderBook, error) {
 	// TODO implement

--- a/plugins/ccxtExchange.go
+++ b/plugins/ccxtExchange.go
@@ -9,9 +9,8 @@ import (
 	"github.com/lightyeario/kelp/support/utils"
 )
 
-// TODO should confirm to the api.Exchange interface
-// ensure that ccxtExchange conforms to the TickerAPI interface for now
-var _ api.TickerAPI = ccxtExchange{}
+// ensure that ccxtExchange conforms to the Exchange interface
+var _ api.Exchange = ccxtExchange{}
 
 // ccxtExchange is the implementation for the CCXT REST library that supports many exchanges (https://github.com/franz-see/ccxt-rest, https://github.com/ccxt/ccxt/)
 type ccxtExchange struct {
@@ -22,8 +21,7 @@ type ccxtExchange struct {
 }
 
 // makeCcxtExchange is a factory method to make an exchange using the CCXT interface
-// TODO should return api.Exchange
-func makeCcxtExchange(ccxtBaseURL string, exchangeName string) (api.TickerAPI, error) {
+func makeCcxtExchange(ccxtBaseURL string, exchangeName string) (api.Exchange, error) {
 	c, e := sdk.MakeInitializedCcxtExchange(ccxtBaseURL, exchangeName)
 	if e != nil {
 		return nil, fmt.Errorf("error making a ccxt exchange: %s", e)
@@ -60,4 +58,79 @@ func (c ccxtExchange) GetTickerPrice(pairs []model.TradingPair) (map[model.Tradi
 	}
 
 	return priceResult, nil
+}
+
+// GetAssetConverter impl
+func (c ccxtExchange) GetAssetConverter() *model.AssetConverter {
+	return c.assetConverter
+}
+
+// GetAccountBalances impl
+func (c ccxtExchange) GetAccountBalances(assetList []model.Asset) (map[model.Asset]model.Number, error) {
+	// TODO implement
+	return nil, nil
+}
+
+// GetPrecision impl
+func (c ccxtExchange) GetPrecision() int8 {
+	// TODO implement
+	return utils.SdexPrecision
+}
+
+// GetOrderBook impl
+func (c ccxtExchange) GetOrderBook(pair *model.TradingPair, maxCount int32) (*model.OrderBook, error) {
+	// TODO implement
+	return nil, nil
+}
+
+// GetTrades impl
+func (c ccxtExchange) GetTrades(pair *model.TradingPair, maybeCursor interface{}) (*api.TradesResult, error) {
+	// TODO implement
+	return nil, nil
+}
+
+// GetTradeHistory impl
+func (c ccxtExchange) GetTradeHistory(maybeCursorStart interface{}, maybeCursorEnd interface{}) (*api.TradeHistoryResult, error) {
+	// TODO implement
+	return nil, nil
+}
+
+// GetOpenOrders impl
+func (c ccxtExchange) GetOpenOrders() (map[model.TradingPair][]model.OpenOrder, error) {
+	// TODO implement
+	return nil, nil
+}
+
+// AddOrder impl
+func (c ccxtExchange) AddOrder(order *model.Order) (*model.TransactionID, error) {
+	// TODO implement
+	return nil, nil
+}
+
+// CancelOrder impl
+func (c ccxtExchange) CancelOrder(txID *model.TransactionID) (model.CancelOrderResult, error) {
+	// TODO implement
+	return model.CancelResultCancelSuccessful, nil
+}
+
+// PrepareDeposit impl
+func (c ccxtExchange) PrepareDeposit(asset model.Asset, amount *model.Number) (*api.PrepareDepositResult, error) {
+	// TODO implement
+	return nil, nil
+}
+
+// GetWithdrawInfo impl
+func (c ccxtExchange) GetWithdrawInfo(asset model.Asset, amountToWithdraw *model.Number, address string) (*api.WithdrawInfo, error) {
+	// TODO implement
+	return nil, nil
+}
+
+// WithdrawFunds impl
+func (c ccxtExchange) WithdrawFunds(
+	asset model.Asset,
+	amountToWithdraw *model.Number,
+	address string,
+) (*api.WithdrawFunds, error) {
+	// TODO implement
+	return nil, nil
 }

--- a/plugins/ccxtExchange.go
+++ b/plugins/ccxtExchange.go
@@ -1,0 +1,63 @@
+package plugins
+
+import (
+	"fmt"
+
+	"github.com/lightyeario/kelp/api"
+	"github.com/lightyeario/kelp/model"
+	"github.com/lightyeario/kelp/support/sdk"
+	"github.com/lightyeario/kelp/support/utils"
+)
+
+// TODO should confirm to the api.Exchange interface
+// ensure that ccxtExchange conforms to the TickerAPI interface for now
+var _ api.TickerAPI = ccxtExchange{}
+
+// ccxtExchange is the implementation for the CCXT REST library that supports many exchanges (https://github.com/franz-see/ccxt-rest, https://github.com/ccxt/ccxt/)
+type ccxtExchange struct {
+	assetConverter *model.AssetConverter
+	delimiter      string
+	api            *sdk.Ccxt
+	precision      int8
+}
+
+// makeCcxtExchange is a factory method to make an exchange using the CCXT interface
+// TODO should return api.Exchange
+func makeCcxtExchange(ccxtBaseURL string, exchangeName string) (api.TickerAPI, error) {
+	c, e := sdk.MakeInitializedCcxtExchange(ccxtBaseURL, exchangeName)
+	if e != nil {
+		return nil, fmt.Errorf("error making a ccxt exchange: %s", e)
+	}
+
+	return ccxtExchange{
+		assetConverter: model.CcxtAssetConverter,
+		delimiter:      "/",
+		api:            c,
+		precision:      utils.SdexPrecision,
+	}, nil
+}
+
+// GetTickerPrice impl.
+func (c ccxtExchange) GetTickerPrice(pairs []model.TradingPair) (map[model.TradingPair]api.Ticker, error) {
+	pairsMap, e := model.TradingPairs2Strings(c.assetConverter, c.delimiter, pairs)
+	if e != nil {
+		return nil, e
+	}
+
+	priceResult := map[model.TradingPair]api.Ticker{}
+	for _, p := range pairs {
+		tickerMap, e := c.api.FetchTicker(pairsMap[p])
+		if e != nil {
+			return nil, fmt.Errorf("error while fetching ticker price for trading pair %s: %s", pairsMap[p], e)
+		}
+
+		priceResult[p] = api.Ticker{
+			AskPrice:  model.NumberFromFloat(tickerMap["ask"].(float64), c.precision),
+			AskVolume: model.NumberFromFloat(tickerMap["askVolume"].(float64), c.precision),
+			BidPrice:  model.NumberFromFloat(tickerMap["bid"].(float64), c.precision),
+			BidVolume: model.NumberFromFloat(tickerMap["bidVolume"].(float64), c.precision),
+		}
+	}
+
+	return priceResult, nil
+}

--- a/plugins/ccxtExchange_test.go
+++ b/plugins/ccxtExchange_test.go
@@ -1,0 +1,27 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/lightyeario/kelp/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTickerPrice_Ccxt(t *testing.T) {
+	testCcxtExchange, e := makeCcxtExchange("http://localhost:3000", "binance")
+	if !assert.NoError(t, e) {
+		return
+	}
+
+	pair := model.TradingPair{Base: model.XLM, Quote: model.BTC}
+	pairs := []model.TradingPair{pair}
+
+	m, e := testCcxtExchange.GetTickerPrice(pairs)
+	if !assert.NoError(t, e) {
+		return
+	}
+	assert.Equal(t, 1, len(m))
+
+	ticker := m[pair]
+	assert.True(t, ticker.AskPrice.AsFloat() < 1, ticker.AskPrice.AsString())
+}

--- a/plugins/ccxtExchange_test.go
+++ b/plugins/ccxtExchange_test.go
@@ -1,13 +1,14 @@
 package plugins
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/lightyeario/kelp/model"
 	"github.com/stretchr/testify/assert"
 )
 
-var supportedExchanges = []string{"binance", "poloniex"}
+var supportedExchanges = []string{"binance", "poloniex", "bittrex"}
 
 func TestGetTickerPrice_Ccxt(t *testing.T) {
 	for _, exchangeName := range supportedExchanges {
@@ -47,8 +48,8 @@ func TestGetOrderBook_Ccxt(t *testing.T) {
 			}
 			assert.Equal(t, ob.Pair(), &pair)
 
-			assert.True(t, len(ob.Asks()) > 0, len(ob.Asks()))
-			assert.True(t, len(ob.Bids()) > 0, len(ob.Bids()))
+			assert.True(t, len(ob.Asks()) > 0, fmt.Sprintf("%d", len(ob.Asks())))
+			assert.True(t, len(ob.Bids()) > 0, fmt.Sprintf("%d", len(ob.Bids())))
 			assert.True(t, ob.Asks()[0].OrderAction.IsSell())
 			assert.True(t, ob.Asks()[0].OrderType.IsLimit())
 			assert.True(t, ob.Bids()[0].OrderAction.IsBuy())
@@ -57,6 +58,56 @@ func TestGetOrderBook_Ccxt(t *testing.T) {
 			assert.True(t, ob.Asks()[0].Volume.AsFloat() > 0)
 			assert.True(t, ob.Bids()[0].Price.AsFloat() > 0)
 			assert.True(t, ob.Bids()[0].Volume.AsFloat() > 0)
+		})
+	}
+}
+
+func TestGetTrades_Ccxt(t *testing.T) {
+	for _, exchangeName := range supportedExchanges {
+		t.Run(exchangeName, func(t *testing.T) {
+			testCcxtExchange, e := makeCcxtExchange("http://localhost:3000", exchangeName)
+			if !assert.NoError(t, e) {
+				return
+			}
+
+			pair := model.TradingPair{Base: model.XLM, Quote: model.BTC}
+			// TODO test with cursor once implemented
+			tradeResult, e := testCcxtExchange.GetTrades(&pair, nil)
+			if !assert.NoError(t, e) {
+				return
+			}
+			assert.Equal(t, nil, tradeResult.Cursor)
+
+			for _, trade := range tradeResult.Trades {
+				if !assert.Equal(t, &pair, trade.Pair) {
+					return
+				}
+				if !assert.True(t, trade.Price.AsFloat() > 0, fmt.Sprintf("%.7f", trade.Price.AsFloat())) {
+					return
+				}
+				if !assert.True(t, trade.Volume.AsFloat() > 0, fmt.Sprintf("%.7f", trade.Volume.AsFloat())) {
+					return
+				}
+				if !assert.Equal(t, trade.OrderType, model.OrderTypeLimit) {
+					return
+				}
+				if !assert.True(t, trade.Timestamp.AsInt64() > 0, fmt.Sprintf("%d", trade.Timestamp.AsInt64())) {
+					return
+				}
+				if !assert.NotNil(t, trade.TransactionID) {
+					return
+				}
+				if !assert.Nil(t, trade.Fee) {
+					return
+				}
+				if trade.OrderAction != model.OrderActionBuy && trade.OrderAction != model.OrderActionSell {
+					assert.Fail(t, "trade.OrderAction should be either OrderActionBuy or OrderActionSell: %v", trade.OrderAction)
+					return
+				}
+				if trade.Cost != nil && !assert.True(t, trade.Cost.AsFloat() > 0, fmt.Sprintf("%.7f", trade.Cost.AsFloat())) {
+					return
+				}
+			}
 		})
 	}
 }

--- a/plugins/ccxtExchange_test.go
+++ b/plugins/ccxtExchange_test.go
@@ -25,3 +25,28 @@ func TestGetTickerPrice_Ccxt(t *testing.T) {
 	ticker := m[pair]
 	assert.True(t, ticker.AskPrice.AsFloat() < 1, ticker.AskPrice.AsString())
 }
+
+func TestGetOrderBook_Ccxt(t *testing.T) {
+	testCcxtExchange, e := makeCcxtExchange("http://localhost:3000", "binance")
+	if !assert.NoError(t, e) {
+		return
+	}
+
+	pair := model.TradingPair{Base: model.XLM, Quote: model.BTC}
+	ob, e := testCcxtExchange.GetOrderBook(&pair, 10)
+	if !assert.NoError(t, e) {
+		return
+	}
+	assert.Equal(t, ob.Pair(), &pair)
+
+	assert.True(t, len(ob.Asks()) > 0, len(ob.Asks()))
+	assert.True(t, len(ob.Bids()) > 0, len(ob.Bids()))
+	assert.True(t, ob.Asks()[0].OrderAction.IsSell())
+	assert.True(t, ob.Asks()[0].OrderType.IsLimit())
+	assert.True(t, ob.Bids()[0].OrderAction.IsBuy())
+	assert.True(t, ob.Bids()[0].OrderType.IsLimit())
+	assert.True(t, ob.Asks()[0].Price.AsFloat() > 0)
+	assert.True(t, ob.Asks()[0].Volume.AsFloat() > 0)
+	assert.True(t, ob.Bids()[0].Price.AsFloat() > 0)
+	assert.True(t, ob.Bids()[0].Volume.AsFloat() > 0)
+}

--- a/plugins/ccxtExchange_test.go
+++ b/plugins/ccxtExchange_test.go
@@ -7,46 +7,56 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var supportedExchanges = []string{"binance", "poloniex"}
+
 func TestGetTickerPrice_Ccxt(t *testing.T) {
-	testCcxtExchange, e := makeCcxtExchange("http://localhost:3000", "binance")
-	if !assert.NoError(t, e) {
-		return
+	for _, exchangeName := range supportedExchanges {
+		t.Run(exchangeName, func(t *testing.T) {
+			testCcxtExchange, e := makeCcxtExchange("http://localhost:3000", exchangeName)
+			if !assert.NoError(t, e) {
+				return
+			}
+
+			pair := model.TradingPair{Base: model.XLM, Quote: model.BTC}
+			pairs := []model.TradingPair{pair}
+
+			m, e := testCcxtExchange.GetTickerPrice(pairs)
+			if !assert.NoError(t, e) {
+				return
+			}
+			assert.Equal(t, 1, len(m))
+
+			ticker := m[pair]
+			assert.True(t, ticker.AskPrice.AsFloat() < 1, ticker.AskPrice.AsString())
+		})
 	}
-
-	pair := model.TradingPair{Base: model.XLM, Quote: model.BTC}
-	pairs := []model.TradingPair{pair}
-
-	m, e := testCcxtExchange.GetTickerPrice(pairs)
-	if !assert.NoError(t, e) {
-		return
-	}
-	assert.Equal(t, 1, len(m))
-
-	ticker := m[pair]
-	assert.True(t, ticker.AskPrice.AsFloat() < 1, ticker.AskPrice.AsString())
 }
 
 func TestGetOrderBook_Ccxt(t *testing.T) {
-	testCcxtExchange, e := makeCcxtExchange("http://localhost:3000", "binance")
-	if !assert.NoError(t, e) {
-		return
-	}
+	for _, exchangeName := range supportedExchanges {
+		t.Run(exchangeName, func(t *testing.T) {
+			testCcxtExchange, e := makeCcxtExchange("http://localhost:3000", exchangeName)
+			if !assert.NoError(t, e) {
+				return
+			}
 
-	pair := model.TradingPair{Base: model.XLM, Quote: model.BTC}
-	ob, e := testCcxtExchange.GetOrderBook(&pair, 10)
-	if !assert.NoError(t, e) {
-		return
-	}
-	assert.Equal(t, ob.Pair(), &pair)
+			pair := model.TradingPair{Base: model.XLM, Quote: model.BTC}
+			ob, e := testCcxtExchange.GetOrderBook(&pair, 10)
+			if !assert.NoError(t, e) {
+				return
+			}
+			assert.Equal(t, ob.Pair(), &pair)
 
-	assert.True(t, len(ob.Asks()) > 0, len(ob.Asks()))
-	assert.True(t, len(ob.Bids()) > 0, len(ob.Bids()))
-	assert.True(t, ob.Asks()[0].OrderAction.IsSell())
-	assert.True(t, ob.Asks()[0].OrderType.IsLimit())
-	assert.True(t, ob.Bids()[0].OrderAction.IsBuy())
-	assert.True(t, ob.Bids()[0].OrderType.IsLimit())
-	assert.True(t, ob.Asks()[0].Price.AsFloat() > 0)
-	assert.True(t, ob.Asks()[0].Volume.AsFloat() > 0)
-	assert.True(t, ob.Bids()[0].Price.AsFloat() > 0)
-	assert.True(t, ob.Bids()[0].Volume.AsFloat() > 0)
+			assert.True(t, len(ob.Asks()) > 0, len(ob.Asks()))
+			assert.True(t, len(ob.Bids()) > 0, len(ob.Bids()))
+			assert.True(t, ob.Asks()[0].OrderAction.IsSell())
+			assert.True(t, ob.Asks()[0].OrderType.IsLimit())
+			assert.True(t, ob.Bids()[0].OrderAction.IsBuy())
+			assert.True(t, ob.Bids()[0].OrderType.IsLimit())
+			assert.True(t, ob.Asks()[0].Price.AsFloat() > 0)
+			assert.True(t, ob.Asks()[0].Volume.AsFloat() > 0)
+			assert.True(t, ob.Bids()[0].Price.AsFloat() > 0)
+			assert.True(t, ob.Bids()[0].Volume.AsFloat() > 0)
+		})
+	}
 }

--- a/plugins/exchangeFeed.go
+++ b/plugins/exchangeFeed.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/lightyeario/kelp/api"
 	"github.com/lightyeario/kelp/model"
@@ -9,6 +10,7 @@ import (
 
 // encapsulates a priceFeed from a tickerAPI
 type exchangeFeed struct {
+	name      string
 	tickerAPI *api.TickerAPI
 	pairs     []model.TradingPair
 }
@@ -16,8 +18,9 @@ type exchangeFeed struct {
 // ensure that it implements PriceFeed
 var _ api.PriceFeed = &exchangeFeed{}
 
-func newExchangeFeed(tickerAPI *api.TickerAPI, pair *model.TradingPair) *exchangeFeed {
+func newExchangeFeed(name string, tickerAPI *api.TickerAPI, pair *model.TradingPair) *exchangeFeed {
 	return &exchangeFeed{
+		name:      name,
 		tickerAPI: tickerAPI,
 		pairs:     []model.TradingPair{*pair},
 	}
@@ -28,7 +31,7 @@ func (f *exchangeFeed) GetPrice() (float64, error) {
 	tickerAPI := *f.tickerAPI
 	m, e := tickerAPI.GetTickerPrice(f.pairs)
 	if e != nil {
-		return 0, e
+		return 0, fmt.Errorf("error while getting price from exchange feed: %s", e)
 	}
 
 	p, ok := m[f.pairs[0]]
@@ -37,5 +40,6 @@ func (f *exchangeFeed) GetPrice() (float64, error) {
 	}
 
 	centerPrice := (p.BidPrice.AsFloat() + p.AskPrice.AsFloat()) / 2
+	log.Printf("price from exchange feed (%s): bidPrice=%.7f, askPrice=%.7f, centerPrice=%.7f", f.name, p.BidPrice.AsFloat(), p.AskPrice.AsFloat(), centerPrice)
 	return centerPrice, nil
 }

--- a/plugins/exchangeFeed.go
+++ b/plugins/exchangeFeed.go
@@ -7,26 +7,26 @@ import (
 	"github.com/lightyeario/kelp/model"
 )
 
-// encapsulates a priceFeed from a tradeAPI
+// encapsulates a priceFeed from a tickerAPI
 type exchangeFeed struct {
-	tradeAPI *api.TradeAPI
-	pairs    []model.TradingPair
+	tickerAPI *api.TickerAPI
+	pairs     []model.TradingPair
 }
 
 // ensure that it implements PriceFeed
 var _ api.PriceFeed = &exchangeFeed{}
 
-func newExchangeFeed(tradeAPI *api.TradeAPI, pair *model.TradingPair) *exchangeFeed {
+func newExchangeFeed(tickerAPI *api.TickerAPI, pair *model.TradingPair) *exchangeFeed {
 	return &exchangeFeed{
-		tradeAPI: tradeAPI,
-		pairs:    []model.TradingPair{*pair},
+		tickerAPI: tickerAPI,
+		pairs:     []model.TradingPair{*pair},
 	}
 }
 
 // GetPrice impl
 func (f *exchangeFeed) GetPrice() (float64, error) {
-	tradeAPI := *f.tradeAPI
-	m, e := tradeAPI.GetTickerPrice(f.pairs)
+	tickerAPI := *f.tickerAPI
+	m, e := tickerAPI.GetTickerPrice(f.pairs)
 	if e != nil {
 		return 0, e
 	}

--- a/plugins/factory.go
+++ b/plugins/factory.go
@@ -132,15 +132,21 @@ var exchanges = map[string]exchangeContainer{
 		makeFn:      makeKrakenExchange,
 	},
 	"ccxt-binance": exchangeContainer{
-		description: "Binance is a popular centralized cryptocurrency exchange (via ccxt-rest)",
+		description: "Binance is a popular centralized cryptocurrency exchange (via ccxt-rest) - partial implementation",
 		makeFn: func() (api.Exchange, error) {
 			return makeCcxtExchange("http://localhost:3000", "binance")
 		},
 	},
 	"ccxt-poloniex": exchangeContainer{
-		description: "Poloniex is a popular centralized cryptocurrency exchange (via ccxt-rest)",
+		description: "Poloniex is a popular centralized cryptocurrency exchange (via ccxt-rest) - partial implementation",
 		makeFn: func() (api.Exchange, error) {
 			return makeCcxtExchange("http://localhost:3000", "poloniex")
+		},
+	},
+	"ccxt-bittrex": exchangeContainer{
+		description: "Bittrex is a popular centralized cryptocurrency exchange (via ccxt-rest) - partial implementation",
+		makeFn: func() (api.Exchange, error) {
+			return makeCcxtExchange("http://localhost:3000", "bittrex")
 		},
 	},
 }

--- a/plugins/factory.go
+++ b/plugins/factory.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/lightyeario/kelp/api"
 	"github.com/lightyeario/kelp/support/utils"
@@ -99,6 +100,7 @@ func MakeStrategy(
 	strategy string,
 	stratConfigPath string,
 ) (api.Strategy, error) {
+	log.Printf("Making strategy: %s\n", strategy)
 	if strat, ok := strategies[strategy]; ok {
 		if strat.NeedsConfig && stratConfigPath == "" {
 			return nil, fmt.Errorf("the '%s' strategy needs a config file", strategy)

--- a/plugins/factory.go
+++ b/plugins/factory.go
@@ -134,14 +134,12 @@ var exchanges = map[string]exchangeContainer{
 	"ccxt-binance": exchangeContainer{
 		description: "Binance is a popular centralized cryptocurrency exchange (via ccxt-rest)",
 		makeFn: func() (api.Exchange, error) {
-			// TODO this URL should be taken from the bot config and this factory.go needs to be structified
 			return makeCcxtExchange("http://localhost:3000", "binance")
 		},
 	},
 	"ccxt-poloniex": exchangeContainer{
 		description: "Poloniex is a popular centralized cryptocurrency exchange (via ccxt-rest)",
 		makeFn: func() (api.Exchange, error) {
-			// TODO this URL should be taken from the bot config and this factory.go needs to be structified
 			return makeCcxtExchange("http://localhost:3000", "poloniex")
 		},
 	},

--- a/plugins/factory.go
+++ b/plugins/factory.go
@@ -138,6 +138,13 @@ var exchanges = map[string]exchangeContainer{
 			return makeCcxtExchange("http://localhost:3000", "binance")
 		},
 	},
+	"ccxt-poloniex": exchangeContainer{
+		description: "Poloniex is a popular centralized cryptocurrency exchange (via ccxt-rest)",
+		makeFn: func() (api.Exchange, error) {
+			// TODO this URL should be taken from the bot config and this factory.go needs to be structified
+			return makeCcxtExchange("http://localhost:3000", "poloniex")
+		},
+	},
 }
 
 // MakeExchange is a factory method to make an exchange based on a given type

--- a/plugins/krakenExchange.go
+++ b/plugins/krakenExchange.go
@@ -230,11 +230,6 @@ func (k krakenExchange) readOrders(obi []krakenapi.OrderBookItem, pair *model.Tr
 	return orders
 }
 
-// GetPrecision impl.
-func (k krakenExchange) GetPrecision() int8 {
-	return k.precision
-}
-
 // GetTickerPrice impl.
 func (k krakenExchange) GetTickerPrice(pairs []model.TradingPair) (map[model.TradingPair]api.Ticker, error) {
 	pairsMap, e := model.TradingPairs2Strings(k.assetConverter, k.delimiter, pairs)

--- a/plugins/krakenExchange.go
+++ b/plugins/krakenExchange.go
@@ -251,10 +251,8 @@ func (k krakenExchange) GetTickerPrice(pairs []model.TradingPair) (map[model.Tra
 	for _, p := range pairs {
 		pairTickerInfo := resp.GetPairTickerInfo(pairsMap[p])
 		priceResult[p] = api.Ticker{
-			AskPrice:  model.MustNumberFromString(pairTickerInfo.Ask[0], k.precision),
-			AskVolume: model.MustNumberFromString(pairTickerInfo.Ask[1], k.precision),
-			BidPrice:  model.MustNumberFromString(pairTickerInfo.Bid[0], k.precision),
-			BidVolume: model.MustNumberFromString(pairTickerInfo.Bid[1], k.precision),
+			AskPrice: model.MustNumberFromString(pairTickerInfo.Ask[0], k.precision),
+			BidPrice: model.MustNumberFromString(pairTickerInfo.Bid[0], k.precision),
 		}
 	}
 

--- a/plugins/krakenExchange.go
+++ b/plugins/krakenExchange.go
@@ -45,14 +45,14 @@ func (m asset2Address2Key) getKey(asset model.Asset, address string) (string, er
 
 // makeKrakenExchange is a factory method to make the kraken exchange
 // TODO 2, should take in config file for kraken api keys + withdrawalKeys mapping
-func makeKrakenExchange() api.Exchange {
+func makeKrakenExchange() (api.Exchange, error) {
 	return &krakenExchange{
 		assetConverter: model.KrakenAssetConverter,
 		api:            krakenapi.New("", ""),
 		delimiter:      "",
 		withdrawKeys:   asset2Address2Key{},
 		precision:      8,
-	}
+	}, nil
 }
 
 const pricePrecision = 5

--- a/plugins/krakenExchange_test.go
+++ b/plugins/krakenExchange_test.go
@@ -69,6 +69,7 @@ func TestGetOrderBook(t *testing.T) {
 	if !assert.NoError(t, e) {
 		return
 	}
+	assert.Equal(t, ob.Pair(), &pair)
 
 	assert.True(t, len(ob.Asks()) > 0, len(ob.Asks()))
 	assert.True(t, len(ob.Bids()) > 0, len(ob.Bids()))
@@ -76,6 +77,10 @@ func TestGetOrderBook(t *testing.T) {
 	assert.True(t, ob.Asks()[0].OrderType.IsLimit())
 	assert.True(t, ob.Bids()[0].OrderAction.IsBuy())
 	assert.True(t, ob.Bids()[0].OrderType.IsLimit())
+	assert.True(t, ob.Asks()[0].Price.AsFloat() > 0)
+	assert.True(t, ob.Asks()[0].Volume.AsFloat() > 0)
+	assert.True(t, ob.Bids()[0].Price.AsFloat() > 0)
+	assert.True(t, ob.Bids()[0].Volume.AsFloat() > 0)
 }
 
 func TestGetTrades(t *testing.T) {

--- a/plugins/mirrorStrategy.go
+++ b/plugins/mirrorStrategy.go
@@ -79,9 +79,19 @@ func (s mirrorStrategy) UpdateWithOps(
 		return nil, e
 	}
 
+	// limit bids and asks to max 50 operations each because of Stellar's limit of 100 ops/tx
+	bids := ob.Bids()
+	if len(bids) > 50 {
+		bids = bids[:50]
+	}
+	asks := ob.Asks()
+	if len(asks) > 50 {
+		asks = asks[:50]
+	}
+
 	buyOps, e := s.updateLevels(
 		buyingAOffers,
-		ob.Bids(),
+		bids,
 		s.sdex.ModifyBuyOffer,
 		s.sdex.CreateBuyOffer,
 		(1 - s.config.PER_LEVEL_SPREAD),
@@ -91,9 +101,10 @@ func (s mirrorStrategy) UpdateWithOps(
 		return nil, e
 	}
 	log.Printf("num. buyOps in this update: %d\n", len(buyOps))
+
 	sellOps, e := s.updateLevels(
 		sellingAOffers,
-		ob.Asks(),
+		asks,
 		s.sdex.ModifySellOffer,
 		s.sdex.CreateSellOffer,
 		(1 + s.config.PER_LEVEL_SPREAD),

--- a/plugins/mirrorStrategy.go
+++ b/plugins/mirrorStrategy.go
@@ -39,8 +39,12 @@ type mirrorStrategy struct {
 var _ api.Strategy = &mirrorStrategy{}
 
 // makeMirrorStrategy is a factory method
-func makeMirrorStrategy(sdex *SDEX, baseAsset *horizon.Asset, quoteAsset *horizon.Asset, config *mirrorConfig) api.Strategy {
-	exchange := MakeExchange(config.EXCHANGE)
+func makeMirrorStrategy(sdex *SDEX, baseAsset *horizon.Asset, quoteAsset *horizon.Asset, config *mirrorConfig) (api.Strategy, error) {
+	exchange, e := MakeExchange(config.EXCHANGE)
+	if e != nil {
+		return nil, e
+	}
+
 	orderbookPair := &model.TradingPair{
 		Base:  exchange.GetAssetConverter().MustFromString(config.EXCHANGE_BASE),
 		Quote: exchange.GetAssetConverter().MustFromString(config.EXCHANGE_QUOTE),
@@ -52,7 +56,7 @@ func makeMirrorStrategy(sdex *SDEX, baseAsset *horizon.Asset, quoteAsset *horizo
 		quoteAsset:    quoteAsset,
 		config:        config,
 		tradeAPI:      api.TradeAPI(exchange),
-	}
+	}, nil
 }
 
 // PruneExistingOffers deletes any extra offers

--- a/plugins/priceFeed.go
+++ b/plugins/priceFeed.go
@@ -24,8 +24,8 @@ func MakePriceFeed(feedType string, url string) api.PriceFeed {
 			Base:  exchange.GetAssetConverter().MustFromString(urlParts[1]),
 			Quote: exchange.GetAssetConverter().MustFromString(urlParts[2]),
 		}
-		tradeAPI := api.TradeAPI(exchange)
-		return newExchangeFeed(&tradeAPI, &tradingPair)
+		tickerAPI := api.TickerAPI(exchange)
+		return newExchangeFeed(&tickerAPI, &tradingPair)
 	}
 	return nil
 }

--- a/plugins/priceFeed.go
+++ b/plugins/priceFeed.go
@@ -8,32 +8,45 @@ import (
 )
 
 // MakePriceFeed makes a PriceFeed
-func MakePriceFeed(feedType string, url string) api.PriceFeed {
+func MakePriceFeed(feedType string, url string) (api.PriceFeed, error) {
 	switch feedType {
 	case "crypto":
-		return newCMCFeed(url)
+		return newCMCFeed(url), nil
 	case "fiat":
-		return newFiatFeed(url)
+		return newFiatFeed(url), nil
 	case "fixed":
-		return newFixedFeed(url)
+		return newFixedFeed(url), nil
 	case "exchange":
 		// [0] = exchangeType, [1] = base, [2] = quote
 		urlParts := strings.Split(url, "/")
-		exchange := MakeExchange(urlParts[0])
+		exchange, e := MakeExchange(urlParts[0])
+		if e != nil {
+			return nil, e
+		}
 		tradingPair := model.TradingPair{
 			Base:  exchange.GetAssetConverter().MustFromString(urlParts[1]),
 			Quote: exchange.GetAssetConverter().MustFromString(urlParts[2]),
 		}
 		tickerAPI := api.TickerAPI(exchange)
-		return newExchangeFeed(&tickerAPI, &tradingPair)
+		return newExchangeFeed(&tickerAPI, &tradingPair), nil
 	}
-	return nil
+	return nil, nil
 }
 
 // MakeFeedPair is the factory method that we expose
-func MakeFeedPair(dataTypeA, dataFeedAUrl, dataTypeB, dataFeedBUrl string) *api.FeedPair {
-	return &api.FeedPair{
-		FeedA: MakePriceFeed(dataTypeA, dataFeedAUrl),
-		FeedB: MakePriceFeed(dataTypeB, dataFeedBUrl),
+func MakeFeedPair(dataTypeA, dataFeedAUrl, dataTypeB, dataFeedBUrl string) (*api.FeedPair, error) {
+	feedA, e := MakePriceFeed(dataTypeA, dataFeedAUrl)
+	if e != nil {
+		return nil, e
 	}
+
+	feedB, e := MakePriceFeed(dataTypeB, dataFeedBUrl)
+	if e != nil {
+		return nil, e
+	}
+
+	return &api.FeedPair{
+		FeedA: feedA,
+		FeedB: feedB,
+	}, nil
 }

--- a/plugins/priceFeed.go
+++ b/plugins/priceFeed.go
@@ -22,7 +22,7 @@ func MakePriceFeed(feedType string, url string) (api.PriceFeed, error) {
 		urlParts := strings.Split(url, "/")
 		exchange, e := MakeExchange(urlParts[0])
 		if e != nil {
-			return nil, fmt.Errorf("error making exchange: %s", e)
+			return nil, fmt.Errorf("cannot make priceFeed because of an error when making the '%s' exchange: %s", urlParts[0], e)
 		}
 		tradingPair := model.TradingPair{
 			Base:  exchange.GetAssetConverter().MustFromString(urlParts[1]),
@@ -38,12 +38,12 @@ func MakePriceFeed(feedType string, url string) (api.PriceFeed, error) {
 func MakeFeedPair(dataTypeA, dataFeedAUrl, dataTypeB, dataFeedBUrl string) (*api.FeedPair, error) {
 	feedA, e := MakePriceFeed(dataTypeA, dataFeedAUrl)
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("cannot make a feed pair because of an error when making priceFeed A: %s", e)
 	}
 
 	feedB, e := MakePriceFeed(dataTypeB, dataFeedBUrl)
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("cannot make a feed pair because of an error when making priceFeed B: %s", e)
 	}
 
 	return &api.FeedPair{

--- a/plugins/priceFeed.go
+++ b/plugins/priceFeed.go
@@ -37,7 +37,7 @@ func MakePriceFeed(feedType string, url string) (api.PriceFeed, error) {
 			Quote: quoteAsset,
 		}
 		tickerAPI := api.TickerAPI(exchange)
-		return newExchangeFeed(&tickerAPI, &tradingPair), nil
+		return newExchangeFeed(url, &tickerAPI, &tradingPair), nil
 	}
 	return nil, nil
 }

--- a/plugins/priceFeed.go
+++ b/plugins/priceFeed.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/lightyeario/kelp/api"
@@ -21,7 +22,7 @@ func MakePriceFeed(feedType string, url string) (api.PriceFeed, error) {
 		urlParts := strings.Split(url, "/")
 		exchange, e := MakeExchange(urlParts[0])
 		if e != nil {
-			return nil, e
+			return nil, fmt.Errorf("error making exchange: %s", e)
 		}
 		tradingPair := model.TradingPair{
 			Base:  exchange.GetAssetConverter().MustFromString(urlParts[1]),

--- a/plugins/priceFeed.go
+++ b/plugins/priceFeed.go
@@ -24,9 +24,17 @@ func MakePriceFeed(feedType string, url string) (api.PriceFeed, error) {
 		if e != nil {
 			return nil, fmt.Errorf("cannot make priceFeed because of an error when making the '%s' exchange: %s", urlParts[0], e)
 		}
+		baseAsset, e := exchange.GetAssetConverter().FromString(urlParts[1])
+		if e != nil {
+			return nil, fmt.Errorf("cannot make priceFeed because of an error when converting the base asset: %s", e)
+		}
+		quoteAsset, e := exchange.GetAssetConverter().FromString(urlParts[2])
+		if e != nil {
+			return nil, fmt.Errorf("cannot make priceFeed because of an error when converting the quote asset: %s", e)
+		}
 		tradingPair := model.TradingPair{
-			Base:  exchange.GetAssetConverter().MustFromString(urlParts[1]),
-			Quote: exchange.GetAssetConverter().MustFromString(urlParts[2]),
+			Base:  baseAsset,
+			Quote: quoteAsset,
 		}
 		tickerAPI := api.TickerAPI(exchange)
 		return newExchangeFeed(&tickerAPI, &tradingPair), nil

--- a/plugins/sellStrategy.go
+++ b/plugins/sellStrategy.go
@@ -1,6 +1,8 @@
 package plugins
 
 import (
+	"fmt"
+
 	"github.com/lightyeario/kelp/api"
 	"github.com/lightyeario/kelp/support/utils"
 	"github.com/stellar/go/clients/horizon"
@@ -40,7 +42,7 @@ func makeSellStrategy(
 		config.DATA_FEED_B_URL,
 	)
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("cannot make the sell strategy because we could not make the feed pair: %s", e)
 	}
 
 	offset := rateOffset{

--- a/plugins/sellStrategy.go
+++ b/plugins/sellStrategy.go
@@ -32,13 +32,17 @@ func makeSellStrategy(
 	assetBase *horizon.Asset,
 	assetQuote *horizon.Asset,
 	config *sellConfig,
-) api.Strategy {
-	pf := MakeFeedPair(
+) (api.Strategy, error) {
+	pf, e := MakeFeedPair(
 		config.DATA_TYPE_A,
 		config.DATA_FEED_A_URL,
 		config.DATA_TYPE_B,
 		config.DATA_FEED_B_URL,
 	)
+	if e != nil {
+		return nil, e
+	}
+
 	offset := rateOffset{
 		percent:      config.RATE_OFFSET_PERCENT,
 		absolute:     config.RATE_OFFSET,
@@ -61,5 +65,5 @@ func makeSellStrategy(
 		assetQuote,
 		deleteSideStrategy,
 		sellSideStrategy,
-	)
+	), nil
 }

--- a/support/sdk/ccxt.go
+++ b/support/sdk/ccxt.go
@@ -1,0 +1,86 @@
+package sdk
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/lightyeario/kelp/support/utils"
+)
+
+// Ccxt Rest SDK (https://github.com/franz-see/ccxt-rest, https://github.com/ccxt/ccxt/)
+type Ccxt struct {
+	httpClient   *http.Client
+	ccxtBaseURL  string
+	exchangeName string
+	instanceName string
+}
+
+const pathExchanges = "/exchanges"
+
+// MakeInitializedCcxtExchange constructs an instance of Ccxt that is bound to a specific exchange instance on the CCXT REST server
+func MakeInitializedCcxtExchange(ccxtBaseURL string, exchangeName string) (*Ccxt, error) {
+	if strings.HasSuffix(ccxtBaseURL, "/") {
+		return nil, fmt.Errorf("invalid format for ccxtBaseURL: %s", ccxtBaseURL)
+	}
+
+	c := &Ccxt{
+		httpClient:   http.DefaultClient,
+		ccxtBaseURL:  ccxtBaseURL,
+		exchangeName: exchangeName,
+		// don't initialize instanceName since it's initialized in the call to init() below
+	}
+	e := c.init()
+	if e != nil {
+		return nil, fmt.Errorf("error when initializing Ccxt exchange: %s", e)
+	}
+
+	return c, nil
+}
+
+func (c *Ccxt) init() error {
+	// get exchange list
+	var exchangeList []string
+	e := utils.JSONRequest(c.httpClient, "GET", c.ccxtBaseURL+pathExchanges, "", map[string]string{}, &exchangeList)
+	if e != nil {
+		return fmt.Errorf("error getting list of supported exchanges by CCXT: %s", e)
+	}
+
+	// validate that exchange name is in the exchange list
+	exchangeListed := false
+	for _, name := range exchangeList {
+		if name == c.exchangeName {
+			exchangeListed = true
+			break
+		}
+	}
+	if !exchangeListed {
+		return fmt.Errorf("exchange name '%s' is not in the list of %d exchanges available", c.exchangeName, len(exchangeList))
+	}
+
+	// list all the instances of the exchange
+	var instanceList []string
+	e = utils.JSONRequest(c.httpClient, "GET", c.ccxtBaseURL+pathExchanges+"/"+c.exchangeName, "", map[string]string{}, &instanceList)
+	if e != nil {
+		return fmt.Errorf("error getting list of exchange instances for exchange '%s': %s", c.exchangeName, e)
+	}
+
+	// make a new instance if needed
+	if len(instanceList) == 0 {
+		instanceName := c.exchangeName + "1"
+		var newInstance map[string]interface{}
+		// TODO better JSON structure
+		e = utils.JSONRequest(c.httpClient, "POST", c.ccxtBaseURL+pathExchanges+"/"+c.exchangeName, "{\"id\": \""+instanceName+"\"}", map[string]string{}, &newInstance)
+		if e != nil {
+			return fmt.Errorf("error creating new exchange instance for exchange '%s': %s", c.exchangeName, e)
+		}
+		if _, ok := newInstance["urls"]; !ok {
+			return fmt.Errorf("unable to create a new instance of exchange '%s' with instanceName: %s", c.exchangeName, instanceName)
+		}
+		c.instanceName = instanceName
+	} else {
+		c.instanceName = instanceList[0]
+	}
+
+	return nil
+}

--- a/support/sdk/ccxt.go
+++ b/support/sdk/ccxt.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
@@ -69,23 +70,11 @@ func (c *Ccxt) init() error {
 	// make a new instance if needed
 	if len(instanceList) == 0 {
 		instanceName := c.exchangeName + "1"
-		var data []byte
-		data, e = json.Marshal(&struct {
-			ID string `json:"id"`
-		}{
-			ID: instanceName,
-		})
+		e = c.newInstance(instanceName)
 		if e != nil {
-			return fmt.Errorf("error marshaling instanceName '%s' as ID for exchange '%s': %s", instanceName, c.exchangeName, e)
+			return fmt.Errorf("error creating new instance '%s' for exchange '%s': %s", instanceName, c.exchangeName, e)
 		}
-		var newInstance map[string]interface{}
-		e = utils.JSONRequest(c.httpClient, "POST", c.ccxtBaseURL+pathExchanges+"/"+c.exchangeName, string(data), map[string]string{}, &newInstance)
-		if e != nil {
-			return fmt.Errorf("error creating new exchange instance for exchange '%s': %s", c.exchangeName, e)
-		}
-		if _, ok := newInstance["urls"]; !ok {
-			return fmt.Errorf("unable to create a new instance of exchange '%s' with instanceName: %s", c.exchangeName, instanceName)
-		}
+		log.Printf("created new instance '%s' for exchange '%s'\n", instanceName, c.exchangeName)
 		c.instanceName = instanceName
 	} else {
 		c.instanceName = instanceList[0]
@@ -101,42 +90,71 @@ func (c *Ccxt) init() error {
 	return nil
 }
 
-// FetchTicker calls the /fetchTicker endpoint on CCXT, trading pair is the CCXT version of the trading pair
-func (c *Ccxt) FetchTicker(tradingPair string) (map[string]interface{}, error) {
+func (c *Ccxt) newInstance(instanceName string) error {
+	data, e := json.Marshal(&struct {
+		ID string `json:"id"`
+	}{
+		ID: instanceName,
+	})
+	if e != nil {
+		return fmt.Errorf("error marshaling instanceName '%s' as ID for exchange '%s': %s", instanceName, c.exchangeName, e)
+	}
+
+	var newInstance map[string]interface{}
+	e = utils.JSONRequest(c.httpClient, "POST", c.ccxtBaseURL+pathExchanges+"/"+c.exchangeName, string(data), map[string]string{}, &newInstance)
+	if e != nil {
+		return fmt.Errorf("error in web request when creating new exchange instance for exchange '%s': %s", c.exchangeName, e)
+	}
+
+	if _, ok := newInstance["urls"]; !ok {
+		return fmt.Errorf("check for new instance of exchange '%s' failed for instanceName: %s", c.exchangeName, instanceName)
+	}
+	return nil
+}
+
+// symbolExists returns an error if the symbol does not exist
+func (c *Ccxt) symbolExists(tradingPair string) error {
 	// get list of symbols available on exchange
 	url := c.ccxtBaseURL + pathExchanges + "/" + c.exchangeName + "/" + c.instanceName
 	// decode generic data (see "https://blog.golang.org/json-and-go#TOC_4.")
 	var exchangeOutput interface{}
 	e := utils.JSONRequest(c.httpClient, "GET", url, "", map[string]string{}, &exchangeOutput)
 	if e != nil {
-		return nil, fmt.Errorf("error fetching details of exchange instance (exchange=%s, instanceName=%s): %s", c.exchangeName, c.instanceName, e)
+		return fmt.Errorf("error fetching details of exchange instance (exchange=%s, instanceName=%s): %s", c.exchangeName, c.instanceName, e)
 	}
 
 	exchangeMap := exchangeOutput.(map[string]interface{})
 	if _, ok := exchangeMap["symbols"]; !ok {
-		return nil, fmt.Errorf("'symbols' field not in result of exchange details (exchange=%s, instanceName=%s)", c.exchangeName, c.instanceName)
+		return fmt.Errorf("'symbols' field not in result of exchange details (exchange=%s, instanceName=%s)", c.exchangeName, c.instanceName)
 	}
+
 	symbolsList := exchangeMap["symbols"].([]interface{})
-	symbolExists := false
 	for _, p := range symbolsList {
 		symbol := p.(string)
 		if tradingPair == symbol {
-			symbolExists = true
-			break
+			// exists
+			return nil
 		}
 	}
-	if !symbolExists {
-		return nil, fmt.Errorf("trading pair '%s' does not exist in the list of %d symbols on exchange '%s'", tradingPair, len(symbolsList), c.exchangeName)
+	return fmt.Errorf("trading pair '%s' does not exist in the list of %d symbols on exchange '%s'", tradingPair, len(symbolsList), c.exchangeName)
+}
+
+// FetchTicker calls the /fetchTicker endpoint on CCXT, trading pair is the CCXT version of the trading pair
+func (c *Ccxt) FetchTicker(tradingPair string) (map[string]interface{}, error) {
+	e := c.symbolExists(tradingPair)
+	if e != nil {
+		return nil, fmt.Errorf("symbol does not exist: %s", e)
 	}
 
-	// fetch ticker for symbol
-	url = c.ccxtBaseURL + pathExchanges + "/" + c.exchangeName + "/" + c.instanceName + "/fetchTicker"
-	// decode generic data (see "https://blog.golang.org/json-and-go#TOC_4.")
-	var data []byte
-	data, e = json.Marshal(&[]string{tradingPair})
+	// marshal input data
+	data, e := json.Marshal(&[]string{tradingPair})
 	if e != nil {
 		return nil, fmt.Errorf("error marshaling tradingPair '%s' as an array for exchange '%s': %s", tradingPair, c.exchangeName, e)
 	}
+
+	// fetch ticker for symbol
+	url := c.ccxtBaseURL + pathExchanges + "/" + c.exchangeName + "/" + c.instanceName + "/fetchTicker"
+	// decode generic data (see "https://blog.golang.org/json-and-go#TOC_4.")
 	var tickerOutput interface{}
 	e = utils.JSONRequest(c.httpClient, "POST", url, string(data), map[string]string{}, &tickerOutput)
 	if e != nil {

--- a/support/sdk/ccxt_test.go
+++ b/support/sdk/ccxt_test.go
@@ -30,3 +30,40 @@ func TestMakeInvalid(t *testing.T) {
 	}
 	// success
 }
+
+func TestFetchTickers(t *testing.T) {
+	c, e := MakeInitializedCcxtExchange("http://localhost:3000", "binance")
+	if e != nil {
+		assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
+		return
+	}
+
+	m, e := c.FetchTicker("BTC/USDT")
+	if e != nil {
+		assert.Fail(t, fmt.Sprintf("error when fetching tickers: %s", e))
+		return
+	}
+
+	assert.Equal(t, "BTC/USDT", m["symbol"].(string))
+	assert.True(t, m["last"].(float64) > 0)
+}
+
+func TestFetchTickersWithMissingSymbol(t *testing.T) {
+	c, e := MakeInitializedCcxtExchange("http://localhost:3000", "binance")
+	if e != nil {
+		assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
+		return
+	}
+
+	_, e = c.FetchTicker("BTC/ABCDEFGH")
+	if e == nil {
+		assert.Fail(t, fmt.Sprintf("expected an error related to symbol '%s' not found but did not receive any error", "BTC/ABCDEFGH"))
+		return
+	}
+
+	if !strings.Contains(e.Error(), "trading pair 'BTC/ABCDEFGH' does not exist") {
+		assert.Fail(t, fmt.Sprintf("unexpected error: %s", e))
+		return
+	}
+	// success
+}

--- a/support/sdk/ccxt_test.go
+++ b/support/sdk/ccxt_test.go
@@ -1,0 +1,32 @@
+package sdk
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeValid(t *testing.T) {
+	_, e := MakeInitializedCcxtExchange("http://localhost:3000", "kraken")
+	if e != nil {
+		assert.Fail(t, fmt.Sprintf("unexpected error: %s", e))
+		return
+	}
+	// success
+}
+
+func TestMakeInvalid(t *testing.T) {
+	_, e := MakeInitializedCcxtExchange("http://localhost:3000", "missing-exchange")
+	if e == nil {
+		assert.Fail(t, "expected an error when trying to make and initialize an exchange that is missing: 'missing-exchange'")
+		return
+	}
+
+	if !strings.Contains(e.Error(), "exchange name 'missing-exchange' is not in the list") {
+		assert.Fail(t, fmt.Sprintf("unexpected error: %s", e))
+		return
+	}
+	// success
+}

--- a/support/sdk/ccxt_test.go
+++ b/support/sdk/ccxt_test.go
@@ -67,3 +67,97 @@ func TestFetchTickersWithMissingSymbol(t *testing.T) {
 	}
 	// success
 }
+
+func TestFetchOrderBook(t *testing.T) {
+	limit5 := 5
+	limit2 := 2
+	for _, k := range []orderbookTest{
+		{
+			exchangeName: "poloniex",
+			tradingPair:  "BTC/USDT",
+			limit:        nil,
+			expectError:  false,
+		}, {
+			exchangeName: "poloniex",
+			tradingPair:  "BTC/USDT",
+			limit:        &limit5,
+			expectError:  false,
+		}, {
+			exchangeName: "poloniex",
+			tradingPair:  "BTC/USDT",
+			limit:        &limit2,
+			expectError:  false,
+		}, {
+			exchangeName: "binance",
+			tradingPair:  "BTC/USDT",
+			limit:        nil,
+			expectError:  false,
+		}, {
+			exchangeName: "binance",
+			tradingPair:  "BTC/USDT",
+			limit:        &limit5,
+			expectError:  false,
+		}, {
+			exchangeName: "binance",
+			tradingPair:  "BTC/USDT",
+			limit:        &limit2,
+			expectError:  true,
+		}, {
+			exchangeName: "poloniex",
+			tradingPair:  "XLM/USDT",
+			limit:        &limit2,
+			expectError:  false,
+		},
+	} {
+		name := fmt.Sprintf("%s-nil", k.exchangeName)
+		if k.limit != nil {
+			name = fmt.Sprintf("%s-%v", k.exchangeName, *k.limit)
+		}
+
+		t.Run(name, func(t *testing.T) {
+			runTestFetchOrderBook(k, t)
+		})
+	}
+}
+
+type orderbookTest struct {
+	exchangeName string
+	tradingPair  string
+	limit        *int
+	expectError  bool
+}
+
+func runTestFetchOrderBook(k orderbookTest, t *testing.T) {
+	c, e := MakeInitializedCcxtExchange("http://localhost:3000", k.exchangeName)
+	if e != nil {
+		assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
+		return
+	}
+
+	m, e := c.FetchOrderBook(k.tradingPair, k.limit)
+	if e != nil && !k.expectError {
+		assert.Fail(t, fmt.Sprintf("error when fetching tickers: %s", e))
+		return
+	} else if e != nil {
+		// success
+		return
+	} else if e == nil && k.expectError {
+		assert.Fail(t, fmt.Sprintf("expected error when fetching tickers but nothing thrown"))
+		return
+	}
+	// else run checks below
+
+	validateOrders := func(key string) {
+		orders, ok := m[key]
+		assert.True(t, ok)
+		if k.limit != nil {
+			assert.Equal(t, len(orders), *k.limit)
+		}
+		for _, o := range orders {
+			assert.True(t, o.Price > 0)
+			assert.True(t, o.Amount > 0)
+		}
+	}
+	validateOrders("asks")
+	validateOrders("bids")
+}

--- a/support/utils/network.go
+++ b/support/utils/network.go
@@ -51,10 +51,12 @@ func JSONRequest(
 		return fmt.Errorf("invalid 'Content-Type' header in http response ('%s'), expecting 'application/json', response body: %s", contentType, string(body))
 	}
 
-	// parse response, the passed in responseData should be a pointer
-	e = json.Unmarshal(body, responseData)
-	if e != nil {
-		return fmt.Errorf("could not unmarshall response body into json: %s | response body: %s", e, string(body))
+	if responseData != nil {
+		// parse response, the passed in responseData should be a pointer
+		e = json.Unmarshal(body, responseData)
+		if e != nil {
+			return fmt.Errorf("could not unmarshall response body into json: %s | response body: %s", e, string(body))
+		}
 	}
 
 	return nil

--- a/support/utils/network.go
+++ b/support/utils/network.go
@@ -1,0 +1,61 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"mime"
+	"net/http"
+	"strings"
+)
+
+// JSONRequest submits an HTTP web request and parses the response into the responseData object as JSON
+func JSONRequest(
+	httpClient *http.Client,
+	method string,
+	reqURL string,
+	data string,
+	headers map[string]string,
+	responseData interface{}, // the passed in responseData should be a pointer
+) error {
+	// create http request
+	req, e := http.NewRequest(method, reqURL, strings.NewReader(data))
+	if e != nil {
+		return fmt.Errorf("could not create http request: %s", e)
+	}
+
+	// add headers
+	for key, value := range headers {
+		req.Header.Add(key, value)
+	}
+
+	// execute request
+	resp, e := httpClient.Do(req)
+	if e != nil {
+		return fmt.Errorf("could not execute http request: %s", e)
+	}
+	defer resp.Body.Close()
+
+	// read response
+	body, e := ioutil.ReadAll(resp.Body)
+	if e != nil {
+		return fmt.Errorf("could not read http response: %s", e)
+	}
+
+	// ensure Content-Type is json
+	contentType, _, e := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if e != nil {
+		return fmt.Errorf("could not read 'Content-Type' header in http response: %s | response body: %s", e, string(body))
+	}
+	if contentType != "application/json" {
+		return fmt.Errorf("invalid 'Content-Type' header in http response ('%s'), expecting 'application/json', response body: %s", contentType, string(body))
+	}
+
+	// parse response, the passed in responseData should be a pointer
+	e = json.Unmarshal(body, responseData)
+	if e != nil {
+		return fmt.Errorf("could not unmarshall response body into json: %s | response body: %s", e, string(body))
+	}
+
+	return nil
+}

--- a/support/utils/network.go
+++ b/support/utils/network.go
@@ -41,21 +41,27 @@ func JSONRequest(
 	if e != nil {
 		return fmt.Errorf("could not read http response: %s", e)
 	}
+	bodyString := string(body)
 
 	// ensure Content-Type is json
 	contentType, _, e := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 	if e != nil {
-		return fmt.Errorf("could not read 'Content-Type' header in http response: %s | response body: %s", e, string(body))
+		return fmt.Errorf("could not read 'Content-Type' header in http response: %s | response body: %s", e, bodyString)
 	}
 	if contentType != "application/json" {
-		return fmt.Errorf("invalid 'Content-Type' header in http response ('%s'), expecting 'application/json', response body: %s", contentType, string(body))
+		return fmt.Errorf("invalid 'Content-Type' header in http response ('%s'), expecting 'application/json', response body: %s", contentType, bodyString)
+	}
+
+	// TODO move this out of this low-level layer
+	if strings.Contains(bodyString, "error") {
+		return fmt.Errorf("error in response: %s", bodyString)
 	}
 
 	if responseData != nil {
 		// parse response, the passed in responseData should be a pointer
 		e = json.Unmarshal(body, responseData)
 		if e != nil {
-			return fmt.Errorf("could not unmarshall response body into json: %s | response body: %s", e, string(body))
+			return fmt.Errorf("could not unmarshall response body into json: %s | response body: %s", e, bodyString)
 		}
 	}
 

--- a/terminator/terminator.go
+++ b/terminator/terminator.go
@@ -96,7 +96,7 @@ func (t *Terminator) run() {
 		}
 
 		log.Printf("updating delete timestamp to %s\n", tsMillisStr)
-		e = t.sdex.SubmitOps(ops)
+		e = t.sdex.SubmitOps(ops, nil)
 		if e != nil {
 			log.Println(e)
 		}
@@ -151,7 +151,7 @@ func (t *Terminator) deleteOffers(sellOffers []horizon.Offer, buyOffers []horizo
 
 	log.Printf("deleting %d offers and 5 data entries, updating delete timestamp to %s\n", numOffers, tsMillisStr)
 	if len(ops) > 0 {
-		e := t.sdex.SubmitOps(ops)
+		e := t.sdex.SubmitOps(ops, nil)
 		if e != nil {
 			log.Println(e)
 			return

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -82,7 +82,7 @@ func (t *Trader) deleteAllOffers() {
 
 	log.Printf("created %d operations to delete offers\n", len(dOps))
 	if len(dOps) > 0 {
-		e := t.sdex.SubmitOps(dOps)
+		e := t.sdex.SubmitOps(dOps, nil)
 		if e != nil {
 			log.Println(e)
 			return
@@ -122,7 +122,7 @@ func (t *Trader) update() {
 	pruneOps, t.buyingAOffers, t.sellingAOffers = t.strat.PruneExistingOffers(t.buyingAOffers, t.sellingAOffers)
 	log.Printf("created %d operations to prune excess offers\n", len(pruneOps))
 	if len(pruneOps) > 0 {
-		e = t.sdex.SubmitOps(pruneOps)
+		e = t.sdex.SubmitOps(pruneOps, nil)
 		if e != nil {
 			log.Println(e)
 			t.deleteAllOffers()
@@ -156,7 +156,7 @@ func (t *Trader) update() {
 
 	log.Printf("created %d operations to update existing offers\n", len(ops))
 	if len(ops) > 0 {
-		e = t.sdex.SubmitOps(ops)
+		e = t.sdex.SubmitOps(ops, nil)
 		if e != nil {
 			log.Println(e)
 			t.deleteAllOffers()


### PR DESCRIPTION
This only implements enough of the CCXT exchange interface so it can be used as a priceFeed for the `sell` and `buysell` strategy, as well as fetching the orderbook so it can be used in the `mirror` strategy.

Currently it is only configured to support binance, poloniex, and bittrex.