### PR TITLE
Travis build runs existing tests, closes #57

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ install:
 script:
 - ./scripts/build.sh
 - ./bin/kelp version
+- go test --short ./...

--- a/plugins/ccxtExchange_test.go
+++ b/plugins/ccxtExchange_test.go
@@ -11,6 +11,10 @@ import (
 var supportedExchanges = []string{"binance", "poloniex", "bittrex"}
 
 func TestGetTickerPrice_Ccxt(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	for _, exchangeName := range supportedExchanges {
 		t.Run(exchangeName, func(t *testing.T) {
 			testCcxtExchange, e := makeCcxtExchange("http://localhost:3000", exchangeName)
@@ -34,6 +38,10 @@ func TestGetTickerPrice_Ccxt(t *testing.T) {
 }
 
 func TestGetOrderBook_Ccxt(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	for _, exchangeName := range supportedExchanges {
 		t.Run(exchangeName, func(t *testing.T) {
 			testCcxtExchange, e := makeCcxtExchange("http://localhost:3000", exchangeName)
@@ -63,6 +71,10 @@ func TestGetOrderBook_Ccxt(t *testing.T) {
 }
 
 func TestGetTrades_Ccxt(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	for _, exchangeName := range supportedExchanges {
 		t.Run(exchangeName, func(t *testing.T) {
 			testCcxtExchange, e := makeCcxtExchange("http://localhost:3000", exchangeName)

--- a/plugins/krakenExchange_test.go
+++ b/plugins/krakenExchange_test.go
@@ -42,11 +42,13 @@ func TestGetTickerPrice(t *testing.T) {
 	if !assert.True(t, ticker.BidPrice.AsFloat() < 1, ticker.BidPrice.AsString()) {
 		return
 	}
-
-	assert.Fail(t, "force fail")
 }
 
 func TestGetAccountBalances(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	assetList := []model.Asset{
 		model.USD,
 		model.XLM,
@@ -104,8 +106,6 @@ func TestGetOrderBook(t *testing.T) {
 	fmt.Printf("first 2 asks:\n")
 	fmt.Println(ob.Asks()[0])
 	fmt.Println(ob.Asks()[1])
-
-	assert.Fail(t, "force fail")
 }
 
 func TestGetTrades(t *testing.T) {
@@ -125,10 +125,14 @@ func TestGetTrades(t *testing.T) {
 		fmt.Println(t.String())
 	}
 
-	assert.Fail(t, "force fail")
+	// assert.Fail(t, "force fail")
 }
 
 func TestGetTradeHistory(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	tradeHistoryResult, e := testKrakenExchange.GetTradeHistory(nil, nil)
 	if !assert.NoError(t, e) {
 		return
@@ -148,6 +152,10 @@ func TestGetTradeHistory(t *testing.T) {
 }
 
 func TestGetOpenOrders(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	m, e := testKrakenExchange.GetOpenOrders()
 	if !assert.NoError(t, e) {
 		return
@@ -169,6 +177,10 @@ func TestGetOpenOrders(t *testing.T) {
 }
 
 func TestAddOrder(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	txID, e := testKrakenExchange.AddOrder(&model.Order{
 		Pair:        &model.TradingPair{Base: model.XLM, Quote: model.USD},
 		OrderAction: model.OrderActionSell,
@@ -189,6 +201,10 @@ func TestAddOrder(t *testing.T) {
 }
 
 func TestCancelOrder(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	// need to add some transactionID here to run this test
 	txID := model.MakeTransactionID("")
 	result, e := testKrakenExchange.CancelOrder(txID)
@@ -205,6 +221,10 @@ func TestCancelOrder(t *testing.T) {
 }
 
 func TestPrepareDeposit(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	result, e := testKrakenExchange.PrepareDeposit(model.BTC, model.NumberFromFloat(1.0, 7))
 	if !assert.NoError(t, e) {
 		return
@@ -215,6 +235,10 @@ func TestPrepareDeposit(t *testing.T) {
 }
 
 func TestGetWithdrawInfo(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	result, e := testKrakenExchange.GetWithdrawInfo(model.BTC, model.NumberFromFloat(1.0, 7), "")
 	if !assert.NoError(t, e) {
 		return
@@ -225,6 +249,10 @@ func TestGetWithdrawInfo(t *testing.T) {
 }
 
 func TestWithdrawFunds(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	result, e := testKrakenExchange.WithdrawFunds(model.XLM, model.NumberFromFloat(0.0000001, 7), "")
 	if !assert.NoError(t, e) {
 		return

--- a/support/monitoring/pagerDuty_test.go
+++ b/support/monitoring/pagerDuty_test.go
@@ -7,6 +7,10 @@ import (
 )
 
 func TestTriggerPagerDuty(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	const kelpServiceKey = "" // Fill in pager duty service key here during testing.
 	testCases := []struct {
 		testName      string

--- a/support/sdk/ccxt_test.go
+++ b/support/sdk/ccxt_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestMakeValid(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	_, e := MakeInitializedCcxtExchange("http://localhost:3000", "kraken")
 	if e != nil {
 		assert.Fail(t, fmt.Sprintf("unexpected error: %s", e))
@@ -18,6 +22,10 @@ func TestMakeValid(t *testing.T) {
 }
 
 func TestMakeInvalid(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	_, e := MakeInitializedCcxtExchange("http://localhost:3000", "missing-exchange")
 	if e == nil {
 		assert.Fail(t, "expected an error when trying to make and initialize an exchange that is missing: 'missing-exchange'")
@@ -32,6 +40,10 @@ func TestMakeInvalid(t *testing.T) {
 }
 
 func TestFetchTickers(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	c, e := MakeInitializedCcxtExchange("http://localhost:3000", "binance")
 	if e != nil {
 		assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
@@ -49,6 +61,10 @@ func TestFetchTickers(t *testing.T) {
 }
 
 func TestFetchTickersWithMissingSymbol(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	c, e := MakeInitializedCcxtExchange("http://localhost:3000", "binance")
 	if e != nil {
 		assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
@@ -69,6 +85,10 @@ func TestFetchTickersWithMissingSymbol(t *testing.T) {
 }
 
 func TestFetchOrderBook(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	limit5 := 5
 	limit2 := 2
 	for _, k := range []orderbookTest{
@@ -128,6 +148,10 @@ type orderbookTest struct {
 }
 
 func runTestFetchOrderBook(k orderbookTest, t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	c, e := MakeInitializedCcxtExchange("http://localhost:3000", k.exchangeName)
 	if e != nil {
 		assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
@@ -163,6 +187,10 @@ func runTestFetchOrderBook(k orderbookTest, t *testing.T) {
 }
 
 func TestFetchTrades(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	poloniexFields := []string{"amount", "cost", "datetime", "id", "price", "side", "symbol", "timestamp", "type"}
 	binanceFields := []string{"amount", "cost", "datetime", "id", "price", "side", "symbol", "timestamp"}
 	bittrexFields := []string{"amount", "datetime", "id", "price", "side", "symbol", "timestamp", "type"}
@@ -203,6 +231,10 @@ type tradesTest struct {
 }
 
 func runTestFetchTrades(k tradesTest, t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
 	c, e := MakeInitializedCcxtExchange("http://localhost:3000", k.exchangeName)
 	if e != nil {
 		assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))


### PR DESCRIPTION
We make use of the `--short` flag when running go tests to disable certain tests that are unfeasible to run in a travis build.